### PR TITLE
Update postgresql version, old one not working

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -16,7 +16,7 @@ dependencies:
     version: 2.30.0
   - name: postgresql
     repository: oci://registry-1.docker.io/bitnamicharts
-    version: 16.6.2
+    version: 18.5.2
   - name: temporal
     version: 0.60.0
     repository: https://go.temporal.io/helm-charts


### PR DESCRIPTION
### What is the problem?
When trying to run the old chart, the postgresql image is getting an image pull error.

Looks like location of the images has changed between version 16 and 18 of the chart.

### What is changed?

postgresql chart version updated from 16.6.2 to 18.5.2