### PR TITLE
Update dependencies

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -4,15 +4,15 @@ dependencies:
   version: 2.30.0
 - name: postgresql
   repository: oci://registry-1.docker.io/bitnamicharts
-  version: 16.6.2
+  version: 18.6.7
 - name: temporal
   repository: https://go.temporal.io/helm-charts
   version: 0.60.0
 - name: keda
   repository: https://kedacore.github.io/charts
-  version: 2.16.1
+  version: 2.19.0
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
   version: 70.4.1
-digest: sha256:58fa1efccc47c03d3f9d6e98abd76d092e368789b7da52e46db15fe91fff289c
-generated: "2025-04-08T13:58:16.746975+01:00"
+digest: sha256:cdfe1365884ebd44580d58ac502f7e96969a890e99f82577608d6d64f3e5b174
+generated: "2026-05-21T15:38:51.497677+10:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -16,13 +16,13 @@ dependencies:
     version: 2.30.0
   - name: postgresql
     repository: oci://registry-1.docker.io/bitnamicharts
-    version: 16.6.2
+    version: 18.6.7
   - name: temporal
     version: 0.60.0
     repository: https://go.temporal.io/helm-charts
   - name: keda
     condition: keda.enabled
-    version: 2.16.1
+    version: 2.19.0
     repository: https://kedacore.github.io/charts
   - name: kube-prometheus-stack
     condition: kube-prometheus-stack.enabled

--- a/values.yaml
+++ b/values.yaml
@@ -221,6 +221,3 @@ kube-prometheus-stack:
 
 keda:
   enabled: true
-  image:
-    keda:
-      tag: "main" # Need to use this until they do a release with the Temporal scaler


### PR DESCRIPTION
Current postgres container throws an `ImagePullBackOff`:
```
% k get pods -n scaling-demo | grep postgres
temporal-postgresql-0                               0/2     ImagePullBackOff        0              4m54s
% kubectl describe pod temporal-postgresql-0 -n scaling-demo | sed -n '/^Events:/,$p'
Events:
  Type     Reason     Age                    From               Message
  ----     ------     ----                   ----               -------
  Normal   Scheduled  4m59s                  default-scheduler  Successfully assigned scaling-demo/temporal-postgresql-0 to minikube
  Warning  Failed     3m17s (x4 over 4m41s)  kubelet            Error: ImagePullBackOff
  Normal   Pulling    3m3s (x4 over 4m57s)   kubelet            Pulling image "docker.io/bitnami/postgresql:17.4.0-debian-12-r14"
  Warning  Failed     2m59s (x4 over 4m50s)  kubelet            Failed to pull image "docker.io/bitnami/postgresql:17.4.0-debian-12-r14": Error response from daemon: manifest for bitnami/postgresql:17.4.0-debian-12-r14 not found: manifest unknown: manifest unknown
  Warning  Failed     2m59s (x4 over 4m50s)  kubelet            Error: ErrImagePull
  Normal   Pulling    2m59s (x4 over 4m50s)  kubelet            Pulling image "docker.io/bitnami/postgres-exporter:0.17.1-debian-12-r4"
  Warning  Failed     2m54s (x4 over 4m41s)  kubelet            Failed to pull image "docker.io/bitnami/postgres-exporter:0.17.1-debian-12-r4": Error response from daemon: manifest for bitnami/postgres-exporter:0.17.1-debian-12-r4 not found: manifest unknown: manifest unknown
  Warning  Failed     2m54s (x4 over 4m41s)  kubelet            Error: ErrImagePull
  Warning  Failed     2m40s (x5 over 4m41s)  kubelet            Error: ImagePullBackOff
  Normal   BackOff    2m1s (x8 over 4m41s)   kubelet            Back-off pulling image "docker.io/bitnami/postgres-exporter:0.17.1-debian-12-r4"
  Normal   BackOff    106s (x9 over 4m41s)   kubelet            Back-off pulling image "docker.io/bitnami/postgresql:17.4.0-debian-12-r14"
```

Updated Postgres & Keda versions to latest in `Chart.yaml`, removed `keda.image.keda.tag` from `values.yaml`.